### PR TITLE
[deployment]修改python模块依赖

### DIFF
--- a/chatGPTEx/requirements.txt
+++ b/chatGPTEx/requirements.txt
@@ -5,11 +5,11 @@ mdit_py_plugins==0.3.5
 Pygments==2.14.0
 regex==2022.7.9
 requests==2.26.0
-tiktoken==0.2.0
 uvicorn==0.20.0
+graiax-playwright==0.2.1
 graiax-text2img-playwright==0.3.0
 python-Levenshtein==0.20.9
 fuzzywuzzy==0.18.0
-tiktoken==0.2.0
+tiktoken==0.3.1
 xpinyin==0.7.6
 jieba==0.42.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ Flask==2.0.2
 fuzzywuzzy==0.18.0
 jieba==0.42.1
 requests==2.26.0
-tiktoken==0.2.0
+tiktoken==0.3.1
 uvicorn==0.21.0
 xpinyin==0.7.6


### PR DESCRIPTION
1. `tiktoken`更换到0.3.1，arm架构可以直接下载wheels。
2. 显式声明`graiax-playwright==0.2.1`，由于tuna那边只同步到v0.2.2，同时该版本再Pypi上已被yank，会导致本地构建出的程序出现`no module graiax.playwright`.